### PR TITLE
Pad images and labels with extra pixels to fix cropping errors for features nears edges

### DIFF
--- a/shell_thickness.ipynb
+++ b/shell_thickness.ipynb
@@ -91,7 +91,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "095d3c0cccea488e96c6d408e6f14e9f",
+       "model_id": "7cf5ad98c5994c78960325e8d6c8a84c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -105,7 +105,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x28251edb808>"
+       "<matplotlib.image.AxesImage at 0x20346621b48>"
       ]
      },
      "execution_count": 4,
@@ -536,7 +536,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "086272d7",
+   "id": "b0ccf0c2",
    "metadata": {},
    "source": [
     "## Shell thickness analysis from HTP dataset and image labels"
@@ -544,7 +544,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 12,
    "id": "61aa4351-0a92-40b4-8fc3-a44f1328aaea",
    "metadata": {},
    "outputs": [],
@@ -560,14 +560,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "d4dda530",
+   "execution_count": 17,
+   "id": "5fe1db0b",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "41c9f03eb48c46e1a3daf30dc2f95bc5",
+       "model_id": "f0c94a20425d495f9340f71fbbf313ae",
        "version_major": 2,
        "version_minor": 0
       },
@@ -599,7 +599,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 11,
    "id": "5d028591-4bc5-4b96-906e-1fe0390900e1",
    "metadata": {
     "scrolled": false
@@ -608,7 +608,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d88ebf97e1e94922895f4d94f5fbf7e3",
+       "model_id": "3bfbb287a8114ca98b27fcf1825b677d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -631,7 +631,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "be33eddb000047a8849cd1bb69940d69",
+       "model_id": "e2c8f94a3dae444092814b4552c49518",
        "version_major": 2,
        "version_minor": 0
       },
@@ -654,7 +654,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "54c734c5d8684cb99799ff1e58cafd86",
+       "model_id": "ca8e641d328f46b5bd23bfa42375d2e7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -677,7 +677,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "352bfde0a27549aa81fc5d8c4ecae088",
+       "model_id": "77999ae324664f5d8f32599cf7b056bf",
        "version_major": 2,
        "version_minor": 0
       },
@@ -700,7 +700,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "cb9c8f246ec44a1b92982f3462a27ac7",
+       "model_id": "ed119a9d65f3402fa785346f06be4f92",
        "version_major": 2,
        "version_minor": 0
       },
@@ -722,15 +722,28 @@
     }
    ],
    "source": [
+    "plt.close('all')\n",
+    "\n",
+    "#input image number in the stack\n",
+    "jj = 3\n",
+    "\n",
+    "cx = properties[jj]['centroid-0']\n",
+    "cx = cx.astype(int) + 300 # account for padded image pixels, (0,0) becomes (0 + padded pixels,0 + padded pixels)\n",
+    "cy = properties[jj]['centroid-1']\n",
+    "cy = cy.astype(int) + 300 # account for padded image pixels\n",
+    "\n",
     "for xc,yc in zip(cx,cy):\n",
-    "    im_cropped = htp_images[jj][xc-200:xc+200, yc-200:yc+200]\n",
-    "    label_cropped = labels[jj][xc-200:xc+200, yc-200:yc+200]\n",
+    "    im_padded = np.pad(htp_images[jj], [(300,), (300,)], mode='constant') #padding images with zeros (adjust based on cropped image dimensions)\n",
+    "    labels_padded = np.pad(labels[jj], [(300,), (300,)], mode='constant') #padding labels with zeros\n",
+    "    \n",
+    "    im_cropped = im_padded[xc-300:xc+300, yc-300:yc+300]\n",
+    "    label_cropped = labels_padded[xc-300:xc+300, yc-300:yc+300]\n",
     "    label_cropped_clean = seg.clear_border(label_cropped, buffer_size=5)\n",
     "    im_cropped_clean = im_cropped * label_cropped_clean\n",
     "    \n",
-    "    radial_sum = radial_sum_profile(im_cropped_clean, (200,200))\n",
-    "    radial_fit_funct = radial_sum[0:99]\n",
-    "    x_values = np.arange(0,99,1)\n",
+    "    radial_sum = radial_sum_profile(im_cropped_clean, (300,300))\n",
+    "    radial_fit_funct = radial_sum[0:99] # adjust based on estimated core size\n",
+    "    x_values = np.arange(0,99) # adjust based on estimated core size\n",
     "    #popt_parab, pcov_parab = scipy.optimize.curve_fit(parabolic_fit, x_values, radial_fit_funct)\n",
     "    popt_cubic, pcov_cubic = scipy.optimize.curve_fit(cubic_fit, x_values, radial_fit_funct)\n",
     "    #perr_parab = np.sqrt(np.diag(pcov_parab))\n",
@@ -755,7 +768,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 9,
    "id": "1173ec85-5d63-4d36-9d26-bdbc59fb22e7",
    "metadata": {},
    "outputs": [],
@@ -803,36 +816,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 10,
    "id": "e4249f1c-ddca-466c-91fe-437a2d3d7072",
    "metadata": {},
    "outputs": [],
    "source": [
     "def cubic_fit(x, a, b, c, d):\n",
     "    return (a*x**3) + (b*x**2) + (c*x) + d"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "95e059c0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# under construction\n",
-    "\n",
-    "cx = []\n",
-    "cy = []\n",
-    "\n",
-    "def HTP_shell_measure(im_start, im_finish, step_size):\n",
-    "    for jj in range(im_start, im_finish, step_size):\n",
-    "        for kk in properties[jj]['label']\n",
-    "            cx = int(properties[jj]['centroid-1'])\n",
-    "            cy = int(properties[jj]['centroid-0'])\n",
-    "        im_cropped = htp_images[jj][xc-200:xc+200, yc-200:yc+200]\n",
-    "        label_cropped = labels[jj][xc-200:xc+200, yc-200:yc+200]\n",
-    "\n",
-    "\n"
    ]
   }
  ],


### PR DESCRIPTION
This fix will pad pixels to the `htp_images` and `labels`. The number of pixels added can be adjusted based on needs such as the sizes of the cropped areas. 

Fixes: #6 